### PR TITLE
Use local jshint/eslint binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test: ## Run tests
 lint: eslint ## Verify source code quality
 
 eslint:
-	@eslint js/ div/*.js test/ cachesw.js
+	@./node_modules/.bin/eslint js/ div/*.js test/ cachesw.js
 
 coverage:
 	istanbul cover _mocha -- -R spec


### PR DESCRIPTION
Fixes 'command not found' errors when jshint or eslint are not installed globally.