### PR TITLE
add apple fullscreen

### DIFF
--- a/bup.html
+++ b/bup.html
@@ -5,6 +5,7 @@
 	<title>Badminton Umpire Panel</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
 	<meta name="mobile-web-app-capable" content="yes"/>
+	<meta name="apple-mobile-web-app-capable" content="yes" />
 	<meta name="theme-color" content="#000"/>
 	<link rel="shortcut icon" type="image/png" href="icons/favicon.png"/>
 <!--@DEV-->


### PR DESCRIPTION
adds full fullscreen support (no adress bar or tabs when using "add to homescreen") for IOS devices (my case: 10.3.4 and 12.5.7)